### PR TITLE
Track OpenAI latency and token usage

### DIFF
--- a/openai_logger.py
+++ b/openai_logger.py
@@ -21,9 +21,9 @@ def log_openai_call(request: dict, response) -> None:
     with _log_lock, open(path, 'a') as f:
         f.write(json.dumps(record) + "\\n")
 
-def log_openai_usage(request: dict, response) -> None:
+def log_openai_usage(request: dict, response, latency: float) -> None:
     """
-    Append user query, response text, and usage info as a JSON object
+    Append user query, response text, usage info, and latency as a JSON object
     (one per line) into logs/openai_usage.jsonl.
     """
     os.makedirs('logs', exist_ok=True)
@@ -51,7 +51,8 @@ def log_openai_usage(request: dict, response) -> None:
         "timestamp": time.time(),
         "user_query": user_query,
         "response_text": response_text,
-        "usage": usage
+        "usage": usage,
+        "latency": latency,
     }
     path = os.path.join('logs', 'openai_usage.jsonl')
     with _log_lock, open(path, 'a') as f:

--- a/openai_service.py
+++ b/openai_service.py
@@ -2,6 +2,7 @@
 OpenAIService class for handling interactions with the Azure OpenAI API
 """
 import logging
+import time
 from openai import AzureOpenAI
 from openai_logger import log_openai_call
 from openai_logger import log_openai_usage
@@ -85,12 +86,22 @@ class OpenAIService:
                 logger.debug(f"First message - Role: {messages[0]['role']}")
                 logger.debug(f"Last message - Role: {messages[-1]['role']}")
             
-            # Send the request to the API
+            # Send the request to the API and record latency
+            start = time.perf_counter()
             response = self.client.chat.completions.create(**request)
-            
+            latency = time.perf_counter() - start
+
+            logger.info(
+                "OpenAI API latency: %.4fs, prompt_tokens: %s, completion_tokens: %s, total_tokens: %s",
+                latency,
+                response.usage.prompt_tokens,
+                response.usage.completion_tokens,
+                response.usage.total_tokens,
+            )
+
             # Log the API call
             log_openai_call(request, response)
-            log_openai_usage(request, response)
+            log_openai_usage(request, response, latency)
             
             # Extract and return the response text
             answer = response.choices[0].message.content


### PR DESCRIPTION
## Summary
- measure OpenAI chat completion latency in `openai_service`
- log latency and token usage to application logger
- include latency in `log_openai_usage` JSON records

## Testing
- `pytest` *(fails: module 'postgres_citation_service' has no attribute 'PostgresCitationService')*
- `pytest tests/test_citations.py -vv`
- `pytest tests/test_postgres_citation_service.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_688db7b35a68832896664c89bc00a3b0