### PR TITLE
Add latency metrics and truncation utility

### DIFF
--- a/db_manager.py
+++ b/db_manager.py
@@ -14,6 +14,7 @@ from config import (
     POSTGRES_PASSWORD,
     POSTGRES_SSL_MODE
 )
+from services.utils import truncate
 
 logger = logging.getLogger(__name__)
 
@@ -410,6 +411,9 @@ class DatabaseManager:
         try:
             # Prepare the data
             timestamp = datetime.now(timezone.utc)
+            query = truncate(query)
+            response = truncate(response)
+            context = truncate(context)
             
             # Create a structured record of the sources with all available metadata
             source_metadata = []

--- a/services/utils.py
+++ b/services/utils.py
@@ -1,0 +1,23 @@
+"""Utility functions shared across services."""
+
+from typing import Optional
+
+
+def truncate(text: Optional[str], limit: int = 200) -> str:
+    """Return text truncated to a maximum of ``limit`` characters.
+
+    Args:
+        text: The string to truncate. ``None`` is treated as an empty string.
+        limit: Maximum length of the returned string.
+
+    Returns:
+        The truncated string. If the original text exceeds ``limit``, the
+        result will end with an ellipsis (``...``).
+    """
+    if text is None:
+        return ""
+    text = str(text)
+    if len(text) <= limit:
+        return text
+    # Reserve space for ellipsis
+    return text[: max(0, limit - 3)] + "..."


### PR DESCRIPTION
## Summary
- measure request latency in `api_query` and `api_query_stream`
- add shared `truncate` helper and apply when logging queries and responses
- ensure database logging stores truncated query, response, and context

## Testing
- `pip install -r requirements.txt` *(fails: PyObjC requires macOS)*
- `pip install python-dotenv`
- `pip install psycopg2-binary`
- `pytest` *(fails: PostgresCitationService missing attribute)*

------
https://chatgpt.com/codex/tasks/task_e_688db91b88c883288730e9fc862cdbae