### PR TITLE
refactor: unify citation source mapping

### DIFF
--- a/static/js/dynamic-container.js
+++ b/static/js/dynamic-container.js
@@ -288,17 +288,13 @@ class DynamicContainer {
     
     // Remove any existing highlights
     this.removeAllHighlights();
-    
-    // Try to get message-specific sources first, then fall back to global lastSources
+
+    // Try to get message-specific sources
     let sourcesToUse = null;
-    
-    // Check if we have message-specific sources
+
     if (messageId && window.messageSourcesMap && window.messageSourcesMap[messageId]) {
       sourcesToUse = window.messageSourcesMap[messageId];
       console.log(`Using message-specific sources for message ${messageId}:`, sourcesToUse);
-    } else if (window.lastSources && Array.isArray(window.lastSources)) {
-      sourcesToUse = window.lastSources;
-      console.log('Using global lastSources:', sourcesToUse);
     }
     
     if (sourcesToUse && Array.isArray(sourcesToUse)) {
@@ -413,7 +409,7 @@ class DynamicContainer {
         if (window.debugLogger) {
           window.debugLogger.log('Source not found for citation', 'error', {
             sourceId: sourceId,
-            availableSources: window.lastSources.length
+            availableSources: sourcesToUse ? sourcesToUse.length : 0
           });
         }
         

--- a/templates/index.html
+++ b/templates/index.html
@@ -810,16 +810,18 @@
     }
     
     // Add sources utilized section function
-    function addSourcesUtilizedSection() {
-      if (window.lastSources && window.lastSources.length > 0) {
-        let sourcesHtml = '<div class="sources-section mt-4 pt-3 border-t border-gray-200">';
-        sourcesHtml += '<h4 class="text-sm font-semibold text-gray-700 mb-2">Sources Utilized</h4>';
-        sourcesHtml += '<ol class="text-sm text-gray-600 space-y-1 pl-4">';
-        
-        window.lastSources.forEach((source, index) => {
-          let sourceTitle = 'Untitled Source';
-          let uniqueId = source.id || `source-${index + 1}`;
-          let displayId = source.display_id || (index + 1).toString();
+    function addSourcesUtilizedSection(sources, messageId) {
+      if (!sources || sources.length === 0) {
+        return;
+      }
+      let sourcesHtml = '<div class="sources-section mt-4 pt-3 border-t border-gray-200">';
+      sourcesHtml += '<h4 class="text-sm font-semibold text-gray-700 mb-2">Sources Utilized</h4>';
+      sourcesHtml += '<ol class="text-sm text-gray-600 space-y-1 pl-4">';
+
+      sources.forEach((source, index) => {
+        let sourceTitle = 'Untitled Source';
+        let uniqueId = source.id || `source-${index + 1}`;
+        let displayId = source.display_id || (index + 1).toString();
           
           if (typeof source === 'string') {
             // If source is just a string, use it as the title (truncated)
@@ -834,12 +836,8 @@
           // Escape HTML in the title to prevent XSS
           sourceTitle = escapeHtml(sourceTitle);
           
-          // Get the message ID from the last bot message
-          const lastBotMessage = document.querySelector('.bot-message:last-child');
-          const messageId = lastBotMessage ? lastBotMessage.getAttribute('data-message-id') : null;
-          
-          // Use unique ID for data-source-id but display the display ID in the text
-          // Include the message ID to ensure we get the right source
+      // Use unique ID for data-source-id but display the display ID in the text
+      // Include the message ID to ensure we get the right source
 
           // Check for legacy/disabled state
           if (source.is_current_message === false) {
@@ -851,26 +849,26 @@
         
         sourcesHtml += '</ol>';
         sourcesHtml += '</div>';
-        
-        // Append to the last bot message
-        const lastBotMessage = document.querySelector('.bot-message:last-child .message-bubble');
-        if (lastBotMessage) {
+
+        // Append to the specified bot message
+        const messageBubble = document.querySelector(`.bot-message[data-message-id="${messageId}"] .message-bubble`);
+        if (messageBubble) {
           // Remove existing sources section to prevent duplicates
-          const existingSection = lastBotMessage.querySelector('.sources-section');
+          const existingSection = messageBubble.querySelector('.sources-section');
           if (existingSection) {
             existingSection.remove();
           }
-          lastBotMessage.innerHTML += sourcesHtml;
-          
+          messageBubble.innerHTML += sourcesHtml;
+
           // Add click event listeners for the new citation links
           // This ensures the newly added links work with the existing citation functionality
           setTimeout(() => {
-            const newCitationLinks = lastBotMessage.querySelectorAll('.citation-link');
+            const newCitationLinks = messageBubble.querySelectorAll('.citation-link');
             newCitationLinks.forEach(link => {
               link.addEventListener('click', function(e) {
                 e.preventDefault();
                 const sourceId = this.getAttribute('data-source-id');
-                
+
                 // Trigger the same behavior as inline citations
                 if (window.handleCitationClick) {
                   window.handleCitationClick(sourceId);
@@ -941,20 +939,11 @@
       if (messageId && window.messageSourcesMap && window.messageSourcesMap[messageId]) {
         sourcesToUse = window.messageSourcesMap[messageId];
         console.log(`Using message-specific sources for message ${messageId}:`, sourcesToUse);
-        
+
         // Find the source by unique ID first, then by display ID as fallback
         source = sourcesToUse.find(s => s.id === sourceId);
         if (!source) {
           source = sourcesToUse.find(s => s.display_id === sourceId);
-        }
-      }
-      
-      // If not found in message-specific sources, try global sources
-      if (!source && window.lastSources && window.lastSources.length > 0) {
-        console.log('Falling back to global lastSources:', window.lastSources);
-        source = window.lastSources.find(s => s.id === sourceId);
-        if (!source) {
-          source = window.lastSources.find(s => s.display_id === sourceId);
         }
       }
       


### PR DESCRIPTION
## Summary
- centralize citation source tracking with `messageSourcesMap` and alias `messageSources`
- stream metadata and citation handlers now use unified map instead of `lastSources`
- remove global `lastSources` fallback in citation utilities and dynamic container

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest` *(fails: AttributeError: module 'postgres_citation_service' has no attribute 'PostgresCitationService')*


------
https://chatgpt.com/codex/tasks/task_e_688db9ddce808328ab60027c235c80ea