### PR TITLE
Add scoped citation identifiers to chat anchors

### DIFF
--- a/static/js/streaming-chat.js
+++ b/static/js/streaming-chat.js
@@ -25,7 +25,7 @@ window.formatMessage = function formatMessage(text) {
     if (!source) return match; // don't break unknown ones
     // The anchor uses the message-scoped citationId for exact handler match
     const citationId = source.scopedId || (window.currentMessageId + '-' + p1);
-    return `<sup><a href="javascript:void(0);" onclick="handleMessageScopedCitationClick('${citationId}')" class="citation-link" data-citation-id="${citationId}">[${p1}]</a></sup>`;
+    return `<sup><a href="javascript:void(0);" onclick="handleMessageScopedCitationClick('${citationId}')" class="citation-link" data-citation-id="${citationId}" data-source-id="${citationId}" data-message-id="${window.currentMessageId}">[${p1}]</a></sup>`;
   });
   return replaced.replace(/\n/g, '<br>');
 };
@@ -238,7 +238,7 @@ function updateStreamingMessage(content) {
       const source = window.lastSources && window.lastSources.find(src => String(src.display_id) === p1);
       if (!source) return match;
       const citationId = source.scopedId || `${window.currentMessageId}-${p1}`;
-      return `<sup><a href="javascript:void(0);" onclick="handleMessageScopedCitationClick('${citationId}')" class="citation-link" data-citation-id="${citationId}">[${p1}]</a></sup>`;
+      return `<sup><a href="javascript:void(0);" onclick="handleMessageScopedCitationClick('${citationId}')" class="citation-link" data-citation-id="${citationId}" data-source-id="${citationId}" data-message-id="${window.currentMessageId}">[${p1}]</a></sup>`;
     });
     contentDiv.innerHTML = html + '<span class="typing-cursor">|</span>';
     

--- a/templates/index.html
+++ b/templates/index.html
@@ -507,7 +507,7 @@
                   uniqueId = source.id;
                 }
               }
-              return `<sup class="text-2xl"><a href="#source-${uniqueId}" class="citation-link text-xs text-blue-600" data-source-id="${uniqueId}" data-message-id="${messageId}">${displayId}</a></sup>`;
+              return `<sup class="text-2xl"><a href="#source-${uniqueId}" class="citation-link text-xs text-blue-600" data-source-id="${uniqueId}" data-citation-id="${uniqueId}" data-message-id="${messageId}">${displayId}</a></sup>`;
             }
             
             // Check if it's an internal source ID [S_xxxxx]
@@ -521,7 +521,7 @@
                   displayId = window.lastSources[sourceIndex].display_id || (sourceIndex + 1).toString();
                 }
               }
-              return `<sup class="text-2xl"><a href="#source-${sourceId}" class="citation-link text-xs text-blue-600" data-source-id="${sourceId}" data-message-id="${messageId}">${displayId}</a></sup>`;
+              return `<sup class="text-2xl"><a href="#source-${sourceId}" class="citation-link text-xs text-blue-600" data-source-id="${sourceId}" data-citation-id="${sourceId}" data-message-id="${messageId}">${displayId}</a></sup>`;
             }
             
             // For any other format, return as-is
@@ -565,7 +565,7 @@
                 uniqueId = source.id;
               }
             }
-            return `<a href="#source-${uniqueId}" class="citation-link text-xs text-blue-600 hover:underline" data-source-id="${uniqueId}">[${displayId}]</a>`;
+            return `<a href="#source-${uniqueId}" class="citation-link text-xs text-blue-600 hover:underline" data-source-id="${uniqueId}" data-citation-id="${uniqueId}">[${displayId}]</a>`;
           }
         );
         return message;
@@ -843,9 +843,9 @@
 
           // Check for legacy/disabled state
           if (source.is_current_message === false) {
-            sourcesHtml += `<li><a href="#source-${uniqueId}" class="citation-link disabled-citation cursor-not-allowed" data-source-id="${uniqueId}" data-message-id="${messageId}" style="pointer-events:none;color:#aaa;opacity:0.5;text-decoration:none;" title="Citations from previous messages are disabled">${sourceTitle}</a></li>`;
+            sourcesHtml += `<li><a href="#source-${uniqueId}" class="citation-link disabled-citation cursor-not-allowed" data-source-id="${uniqueId}" data-citation-id="${uniqueId}" data-message-id="${messageId}" style="pointer-events:none;color:#aaa;opacity:0.5;text-decoration:none;" title="Citations from previous messages are disabled">${sourceTitle}</a></li>`;
           } else {
-            sourcesHtml += `<li><a href="#source-${uniqueId}" class="citation-link text-blue-600 hover:underline cursor-pointer" data-source-id="${uniqueId}" data-message-id="${messageId}">${sourceTitle}</a></li>`;
+            sourcesHtml += `<li><a href="#source-${uniqueId}" class="citation-link text-blue-600 hover:underline cursor-pointer" data-source-id="${uniqueId}" data-citation-id="${uniqueId}" data-message-id="${messageId}">${sourceTitle}</a></li>`;
           }
         });
         
@@ -869,7 +869,7 @@
             newCitationLinks.forEach(link => {
               link.addEventListener('click', function(e) {
                 e.preventDefault();
-                const sourceId = this.getAttribute('data-source-id');
+                const sourceId = this.getAttribute('data-source-id') || this.getAttribute('data-citation-id');
                 
                 // Trigger the same behavior as inline citations
                 if (window.handleCitationClick) {
@@ -1003,9 +1003,9 @@
       if (e.target.classList.contains('citation-link') || e.target.closest('.citation-link')) {
         e.preventDefault();
         const link = e.target.classList.contains('citation-link') ? e.target : e.target.closest('.citation-link');
-        const sourceId = link.getAttribute('data-source-id');
+        const sourceId = link.getAttribute('data-source-id') || link.getAttribute('data-citation-id');
         const messageId = link.getAttribute('data-message-id');
-        
+
         if (sourceId) {
           handleCitationClick(sourceId, messageId);
         }


### PR DESCRIPTION
## Summary
- include `data-source-id` and `data-message-id` on streamed citation links alongside scoped `data-citation-id`
- fall back to `data-citation-id` when `data-source-id` is missing in citation click delegation
- ensure template-generated citation anchors expose both `data-source-id` and `data-citation-id`

## Testing
- `pytest -q` *(fails: AttributeError: module 'postgres_citation_service' has no attribute 'PostgresCitationService')*


------
https://chatgpt.com/codex/tasks/task_e_688db9da505c83288c02a56e81c19383