### PR TITLE
Add basic metrics recording utilities

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,6 +36,7 @@ from config import get_cost_rates
 from openai_service import OpenAIService
 from services.postgres_citation_service import postgres_citation_service
 from services.session_memory import PostgresSessionMemory
+import metrics
 
 setup_logging()
 setup_improvement_logging()
@@ -157,6 +158,7 @@ def llm_helpee(input_text: str) -> str:
     prompt_tokens = usage.prompt_tokens
     completion_tokens = usage.completion_tokens
     total_tokens = usage.total_tokens
+    metrics.record_tokens(os.getenv("AZURE_OPENAI_MODEL"), prompt_tokens, completion_tokens)
     logger.debug(f"User query: {input_text}")
     logger.debug(f"Enhanced query: {answer}")
     # Log to database
@@ -225,6 +227,8 @@ def llm_helpee_2xl(input_text: str) -> str:
     prompt_tokens = usage.prompt_tokens
     completion_tokens = usage.completion_tokens
     total_tokens = usage.total_tokens
+    metrics.record_latency(os.getenv("AZURE_OPENAI_ENDPOINT"), latency)
+    metrics.record_tokens(os.getenv("AZURE_OPENAI_MODEL"), prompt_tokens, completion_tokens)
     
     # Log to database
     log_id = DatabaseManager.log_helpee_activity(

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,54 @@
+import threading
+import logging
+from collections import defaultdict
+
+# Thread-safe storage for metrics
+_lock = threading.Lock()
+_latency_data = defaultdict(list)
+_token_data = defaultdict(lambda: {'prompt': [], 'completion': []})
+
+# Configure metrics logger to write to metrics.log
+_logger = logging.getLogger('metrics')
+if not _logger.handlers:
+    handler = logging.FileHandler('metrics.log')
+    formatter = logging.Formatter('%(asctime)s - %(message)s')
+    handler.setFormatter(formatter)
+    _logger.addHandler(handler)
+    _logger.setLevel(logging.INFO)
+
+
+def record_latency(endpoint: str, ms: float) -> None:
+    """Record latency for a given endpoint."""
+    with _lock:
+        _latency_data[endpoint].append(ms)
+    _logger.info(f"latency endpoint={endpoint} ms={ms}")
+
+
+def record_tokens(model: str, prompt: int, completion: int) -> None:
+    """Record prompt and completion tokens for a model."""
+    with _lock:
+        data = _token_data[model]
+        data['prompt'].append(prompt)
+        data['completion'].append(completion)
+    _logger.info(
+        f"tokens model={model} prompt={prompt} completion={completion}"
+    )
+
+
+def report_metrics() -> dict:
+    """Return average latency and token usage metrics."""
+    with _lock:
+        latency_report = {
+            ep: (sum(vals) / len(vals) if vals else 0.0)
+            for ep, vals in _latency_data.items()
+        }
+        token_report = {}
+        for model, vals in _token_data.items():
+            prompt_vals = vals['prompt']
+            completion_vals = vals['completion']
+            token_report[model] = {
+                'avg_prompt': sum(prompt_vals) / len(prompt_vals) if prompt_vals else 0.0,
+                'avg_completion': sum(completion_vals) / len(completion_vals) if completion_vals else 0.0,
+            }
+    return {'latency': latency_report, 'tokens': token_report}
+

--- a/openai_logger.py
+++ b/openai_logger.py
@@ -2,6 +2,7 @@ import json
 import time
 import os
 from threading import Lock
+import metrics
 
 _log_lock = Lock()
 
@@ -57,3 +58,13 @@ def log_openai_usage(request: dict, response, latency: float) -> None:
     path = os.path.join('logs', 'openai_usage.jsonl')
     with _log_lock, open(path, 'a') as f:
         f.write(json.dumps(record) + "\\n")
+
+    # Record metrics for latency and token usage
+    usage_tokens = usage or {}
+    metrics.record_latency('openai_usage', latency)
+    if usage_tokens:
+        metrics.record_tokens(
+            response_dict.get('model', ''),
+            usage_tokens.get('prompt_tokens', 0),
+            usage_tokens.get('completion_tokens', 0),
+        )

--- a/openai_service.py
+++ b/openai_service.py
@@ -6,6 +6,7 @@ import time
 from openai import AzureOpenAI
 from openai_logger import log_openai_call
 from openai_logger import log_openai_usage
+import metrics
 
 
 
@@ -97,6 +98,14 @@ class OpenAIService:
                 response.usage.prompt_tokens,
                 response.usage.completion_tokens,
                 response.usage.total_tokens,
+            )
+
+            # Record metrics for latency and token usage
+            metrics.record_latency(self.azure_endpoint, latency)
+            metrics.record_tokens(
+                self.deployment_name,
+                response.usage.prompt_tokens,
+                response.usage.completion_tokens,
             )
 
             # Log the API call

--- a/services/llm_service.py
+++ b/services/llm_service.py
@@ -10,6 +10,7 @@ import logging
 from openai import AzureOpenAI
 from db_manager import DatabaseManager
 from config import get_cost_rates
+import metrics
 
 logger = logging.getLogger()
 
@@ -112,12 +113,13 @@ def llm_helpee(input_text: str) -> str:
             { "role": "user",   "content": input_text }
         ]
     )
-    
+
     answer = response.choices[0].message.content
     usage = getattr(response, "usage", {})
     prompt_tokens = usage.prompt_tokens
     completion_tokens = usage.completion_tokens
     total_tokens = usage.total_tokens
+    metrics.record_tokens(os.getenv("AZURE_OPENAI_MODEL"), prompt_tokens, completion_tokens)
     
     logger.debug(f"User query: {input_text}")
     logger.debug(f"Enhanced query: {answer}")
@@ -195,6 +197,8 @@ def llm_helpee_2xl(input_text: str) -> str:
     prompt_tokens = usage.prompt_tokens
     completion_tokens = usage.completion_tokens
     total_tokens = usage.total_tokens
+    metrics.record_latency(os.getenv("AZURE_OPENAI_ENDPOINT"), latency)
+    metrics.record_tokens(os.getenv("AZURE_OPENAI_MODEL"), prompt_tokens, completion_tokens)
     
     # Log to database
     log_id = DatabaseManager.log_helpee_activity(


### PR DESCRIPTION
## Summary
- add `metrics.py` for thread-safe latency/token tracking and reporting
- hook metrics recording into OpenAI service and logger
- capture latency/token metrics when helper functions call OpenAI

## Testing
- `pytest` *(fails: AttributeError: module 'postgres_citation_service' has no attribute 'PostgresCitationService')*

------
https://chatgpt.com/codex/tasks/task_e_688dbad1a9588328bdf4d61b9d022b66