### PR TITLE
Expose model settings for RAG assistant

### DIFF
--- a/main.py
+++ b/main.py
@@ -346,10 +346,16 @@ def api_query():
             if "model" in settings:
                 rag_assistant.deployment_name = settings["model"]
         
-        logger.info(f"DEBUG - Using model: {rag_assistant.deployment_name}")
-        logger.info(f"DEBUG - Temperature: {rag_assistant.temperature}")
-        logger.info(f"DEBUG - Max tokens: {rag_assistant.max_completion_tokens}")
-        logger.info(f"DEBUG - Top P: {rag_assistant.top_p}")
+        if hasattr(rag_assistant, "deployment_name"):
+            logger.info(f"DEBUG - Using model: {rag_assistant.deployment_name}")
+        if hasattr(rag_assistant, "temperature"):
+            logger.info(f"DEBUG - Temperature: {rag_assistant.temperature}")
+        if hasattr(rag_assistant, "max_completion_tokens"):
+            logger.info(
+                f"DEBUG - Max tokens: {rag_assistant.max_completion_tokens}"
+            )
+        if hasattr(rag_assistant, "top_p"):
+            logger.info(f"DEBUG - Top P: {rag_assistant.top_p}")
         
         html_answer, citations = rag_assistant.generate_response(user_query)
         logger.info(f"API query response generated for: {truncate(user_query)}")

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -36,6 +36,9 @@ sys.modules['azure.core.credentials'] = azure_core_stub
 from rag_assistant import EnhancedSimpleRedisRAGAssistant
 from services.postgres_citation_service import postgres_citation_service
 
+# Allow other tests to import the real module
+sys.modules.pop('services.postgres_citation_service', None)
+
 
 class DummyMemory:
     def __init__(self):


### PR DESCRIPTION
## Summary
- Add configurable model settings (deployment name, temperature, token limit, top-p) to `EnhancedSimpleRedisRAGAssistant` and sync deployment updates with `OpenAIService`
- Replace hardcoded token limit with configurable attribute in response generation methods
- Guard API logging with `hasattr` checks and clean up test stub to avoid module import side effects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dcb0f226c83288fb5f170f3f13406